### PR TITLE
Resolve ArgumentError: wrong number of arguments

### DIFF
--- a/lib/graphql_rails/tasks/dump_graphql_schema.rb
+++ b/lib/graphql_rails/tasks/dump_graphql_schema.rb
@@ -9,8 +9,8 @@ module GraphqlRails
 
     attr_reader :name
 
-    def self.call(*args)
-      new(*args).call
+    def self.call(**args)
+      new(**args).call
     end
 
     def initialize(name:)


### PR DESCRIPTION
Resolve ArgumentError: wrong number of arguments (given 1, expected 0; required keyword: name) when run rake graphql_rails:schema:dump in Ruby 3.

Ruby: 3.0.0
Rails: 6.1.4
graphql_rails: 1.2.4

```shell
$ rake graphql_rails:schema:dump
rake aborted!
ArgumentError: wrong number of arguments (given 1, expected 0; required keyword: name)
/Users/cloudolife/.rvm/gems/ruby-3.0.0@graphql_rails-example/gems/graphql_rails-1.2.4/lib/graphql_rails/tasks/dump_graphql_schema.rb:16:in `initialize'
/Users/cloudolife/.rvm/gems/ruby-3.0.0@graphql_rails-example/gems/graphql_rails-1.2.4/lib/graphql_rails/tasks/dump_graphql_schema.rb:13:in `new'
/Users/cloudolife/.rvm/gems/ruby-3.0.0@graphql_rails-example/gems/graphql_rails-1.2.4/lib/graphql_rails/tasks/dump_graphql_schema.rb:13:in `call'
/Users/cloudolife/.rvm/gems/ruby-3.0.0@graphql_rails-example/gems/graphql_rails-1.2.4/lib/graphql_rails/tasks/schema.rake:11:in `block (3 levels) in <main>'
/Users/cloudolife/.rvm/gems/ruby-3.0.0@graphql_rails-example/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
```